### PR TITLE
bugfix: change fstring compatibility with py36

### DIFF
--- a/cythonbuilder/cli.py
+++ b/cythonbuilder/cli.py
@@ -62,7 +62,7 @@ def main():
     if (len(args) == 0):
         display_help()
     cmd1 = helpers.CliTools.pop_arg_or_exit(arglist=args, errormessage=f"[{appsettings.package_name}] {appsettings.package_name} expects at least one argument. Check out [helpy help] for more information")
-    logger.debug(msg=f"{cmd1=}")
+    logger.debug(msg=f"cmd1={cmd1}")
 
 
     # HELPY functions

--- a/cythonbuilder/pyigenerator.py
+++ b/cythonbuilder/pyigenerator.py
@@ -111,7 +111,7 @@ class LineConverter:
 
                     # Strip away parentheses and spaces
                     argument = argument.strip("() ")
-                    logger.debug(f"{argument=}")
+                    logger.debug(f"argument={argument}")
 
 
                     # Rework arguments of c-function to py-style


### PR DESCRIPTION
Hello,
A bug on Python 3.6 has been noticed because of fstring incompatibility.
After this fix, `cythonbuilder build` seems to work on my side. I let you verify on your side. :)
It would be great to upload the fix on pypi, thanks !
Thank you for the project, it's great !